### PR TITLE
Docker for local dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '>=2.7.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4'

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	docker-compose build
 
 start:
-	docker-compose up
+	docker-compose up -d
 
 rspec:
 	docker-compose run -e "RAILS_ENV=test" web rspec spec/
 
-run-background:
-	docker-compose up -d
+start-nobackground:
+	docker-compose up
 
 db_dev_migrate:
 	docker-compose run web rake db:create && docker-compose run web rake db:migrate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# This is a make file to help simplify some of the docker commands we use for running things.
+
+build: 
+	docker-compose build
+
+start:
+	docker-compose up
+
+rspec:
+	docker-compose run -e "RAILS_ENV=test" web rspec spec/
+
+run-background:
+	docker-compose up -d
+
+db_dev_migrate:
+	docker-compose run web rake db:create && docker-compose run web rake db:migrate
+
+db_dev_drop:
+	docker-compose run web rake db:drop
+
+db_dev_reset: db_dev_drop	db_dev_migrate

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ build:
 start:
 	docker-compose up -d
 
-rspec:
-	docker-compose run -e "RAILS_ENV=test" web rspec spec/
-
 start-nobackground:
 	docker-compose up
+
+stop:
+	docker-compose stop
+
+rspec:
+	docker-compose run -e "RAILS_ENV=test" web rspec spec/
 
 db_dev_migrate:
 	docker-compose run web rake db:create && docker-compose run web rake db:migrate

--- a/README.md
+++ b/README.md
@@ -30,3 +30,59 @@ Trello
 
 ## How to Contribute Guide
 [How to Contribute to Voma](How-to-Contribute.md)
+
+## How to run the API using Docker
+
+1. The first thing you'll need to do is install the service on you machine. These [installation instructions](https://docs.docker.com/engine/install/) over at the docker docs site are handy for this part. 
+  - If you're using Windows I highly advise setting up Windows Subsystem for Linux using version 2 or greater. Doing this will make it so our makefile works in your environment and overall just makes it easier to interact with Docker. Luckily, Docker has also provided a [guide for getting this setup](https://docs.docker.com/docker-for-windows/wsl/).
+2. Clone this repo! You can do that by running `git clone https://github.com/Code-For-Chicago/Voma-backend.git` in the terminal application of your choice where ever you want the files to end up.
+3. Try running `make build`
+  - If this is successful you should see some output like this:
+```
+$ make build
+docker-compose build
+db uses an image, skipping
+Building web
+[+] Building 13.0s (17/17) FINISHED
+ => [internal] load build definition from railsServer.Dockerfile                                                     0.0s
+ => => transferring dockerfile: 536B                                                                                 0.0s
+ => [internal] load .dockerignore                                                                                    0.1s
+ => => transferring context: 2B                                                                                      0.0s
+ => resolve image config for docker.io/docker/dockerfile:1                                                          10.9s
+ => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:9e2c9eca7367393aecc68795c671f93466818395a2693498debe  0.0s
+ => [internal] load .dockerignore                                                                                    0.0s
+ => [internal] load build definition from railsServer.Dockerfile                                                     0.0s
+ => [internal] load metadata for docker.io/library/ruby:3                                                            1.6s
+ => [1/8] FROM docker.io/library/ruby:3@sha256:3dbe82eca4730c28fe42929470249ec412ccf17405eaf55efa6427b9d6c171de      0.0s
+ => [internal] load build context                                                                                    0.0s
+ => => transferring context: 6.26kB                                                                                  0.0s
+ => CACHED [2/8] RUN apt-get update -qq && apt-get install -y nodejs postgresql-client                               0.0s
+ => CACHED [3/8] WORKDIR /voma                                                                                       0.0s
+ => CACHED [4/8] COPY Gemfile /voma/Gemfile                                                                          0.0s
+ => CACHED [5/8] COPY Gemfile.lock /voma/Gemfile.lock                                                                0.0s
+ => CACHED [6/8] RUN bundle install                                                                                  0.0s
+ => CACHED [7/8] COPY entrypoint.sh /usr/bin/                                                                        0.0s
+ => CACHED [8/8] RUN chmod +x /usr/bin/entrypoint.sh                                                                 0.0s
+ => exporting to image                                                                                               0.0s
+ => => exporting layers                                                                                              0.0s
+ => => writing image sha256:34d3e8e3664943455a5e0cd2b2491c7c341783382f8ffc76ad4e979345947f30                         0.0s
+ => => naming to docker.io/library/voma-backend_web                                                                  0.0s
+ 1
+ ```
+ 4. Make sure you can start the thing! You can do that by running `make start` or if you'd like to see live output in your terminal you can run `make start-nobackground`. This should give you output like this:
+ ```
+$ make start
+docker-compose up -d
+voma-backend_db_1 is up-to-date
+Recreating voma-backend_web_1 ... done
+ ```
+
+ ## Makefile targets
+
+ - `make start` : This starts the API by spinning up two containers, DB and web. It will run in the background using the `-d` flag for `docker-compose`
+ - `make start-nobackground` : This starts the api by spinning up two containers, DB and web. This will run in the foreground of your terminal and you'll see container output there. This is sometimes handy for debugging.
+ - `make stop` : This will stop the running containers
+ - `make rspec` : This will run rspec tests (unit tests)
+ - `db_dev_migrate` : This will create and migrate the development database
+ - `db_dev_drop` : This will delete the development database
+ - `db_dev_reset` This will delete and then create a new development database

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,9 +17,10 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: db
+  username: postgres
+  password: password
+  pool: 5
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,4 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,3 @@ services:
       - "3000:3000"
     depends_on:
       - db
-      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+  web:
+    build:
+      context: .
+      dockerfile: railsServer.Dockerfile
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/voma
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /voma/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"

--- a/railsServer.Dockerfile
+++ b/railsServer.Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM ruby:3
+RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+WORKDIR /voma
+COPY Gemfile /voma/Gemfile
+COPY Gemfile.lock /voma/Gemfile.lock
+RUN bundle install
+
+# Add a script to be executed every time the container starts.
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+# Configure the main process to run when running the image
+CMD ["rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
This dockerizes the API! 

What does this mean you ask?

Well it means that instead of having to learn and manage rails, ruby, postgres and assorted dependencies on your machine, you instead need to learn and manage your install of docker. This should hopefully speed up the on-boarding process and make it easier for folks to get to a running environment. 

This also adds in a make file. You can read a bit more about the make targets on the readme that was edited in  [this commit](https://github.com/Code-For-Chicago/Voma-backend/pull/10/commits/25151c39f872c0326e7ce2ccd341b7c21d2a0858) for details on how to run the different make targets. The things we should be able to do with those are:
- Start the API services
- Stop the API services
- Create and migrate the development DB
- Reset the development DB
- Run the rspec (unit tests)

Otherwise you can do normal docker stuff to these containers. 